### PR TITLE
Fix ie focus

### DIFF
--- a/src/Select2.less
+++ b/src/Select2.less
@@ -109,7 +109,7 @@
       font-weight: bold;
       position: absolute;
       color: @text-thirdary-color;
-      top: 7px;
+      top: 0;
       right: 20px;
       &:after {
         content: '×'
@@ -330,8 +330,6 @@
     top: -9999px;
     position: absolute;
     outline: none;
-    max-height: 250px;
-    overflow-y: auto;
 
     &-hidden {
       display: none;
@@ -343,6 +341,8 @@
       padding: 0;
       list-style: none;
       z-index: 9999;
+      max-height: 250px;
+      overflow-y: auto;
 
       > li {
         margin: 0;

--- a/src/Select2.less
+++ b/src/Select2.less
@@ -171,7 +171,7 @@
     .@{__select-prefix-cls}-search__field__mirror {
       position: absolute;
       top: -999px;
-      left: 0;
+      left: 0; 
       white-space: pre;
     }
     .@{__select-prefix-cls}-selection-selected-value {
@@ -343,7 +343,7 @@
       z-index: 9999;
       max-height: 250px;
       overflow-y: auto;
-
+    
       > li {
         margin: 0;
         padding: 0;
@@ -375,7 +375,7 @@
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
-
+        
         &-active {
           background-color: @brand-primary-lighter;
           cursor: pointer;
@@ -485,59 +485,59 @@
 }
 
 @keyframes slideUpIn {
-  0% {
-    opacity: 0;
-    transform-origin: 0 0;
-    transform: scaleY(.8);
-  }
+    0% {
+        opacity: 0;
+        transform-origin: 0 0;
+        transform: scaleY(.8);
+    }
 
-  100% {
-    opacity: 1;
-    transform-origin: 0 0;
-    transform: scaleY(1);
-  }
+    100% {
+        opacity: 1;
+        transform-origin: 0 0;
+        transform: scaleY(1);
+    }
 }
 
 @keyframes slideUpOut {
-  0% {
-    opacity: 1;
-    transform-origin: 0 0;
-    transform: scaleY(1);
-  }
+    0% {
+        opacity: 1;
+        transform-origin: 0 0;
+        transform: scaleY(1);
+    }
 
-  100% {
-    opacity: 0;
-    transform-origin: 0 0;
-    transform: scaleY(.8);
-  }
+    100% {
+        opacity: 0;
+        transform-origin: 0 0;
+        transform: scaleY(.8);
+    }
 }
 
 @keyframes slideDownIn {
-  0% {
-    opacity: 0;
-    transform-origin: 100% 100%;
-    transform: scaleY(.8);
-  }
+    0% {
+        opacity: 0;
+        transform-origin: 100% 100%;
+        transform: scaleY(.8);
+    }
 
-  100% {
-    opacity: 1;
-    transform-origin: 100% 100%;
-    transform: scaleY(1);
-  }
+    100% {
+        opacity: 1;
+        transform-origin: 100% 100%;
+        transform: scaleY(1);
+    }
 }
 
 @keyframes slideDownOut {
-  0% {
-    opacity: 1;
-    transform-origin: 100% 100%;
-    transform: scaleY(1);
-  }
+    0% {
+        opacity: 1;
+        transform-origin: 100% 100%;
+        transform: scaleY(1);
+    }
 
-  100% {
-    opacity: 0;
-    transform-origin: 100% 100%;
-    transform: scaleY(.8);
-  }
+    100% {
+        opacity: 0;
+        transform-origin: 100% 100%;
+        transform: scaleY(.8);
+    }
 }
 
 .@{__select-prefix-cls}-dropdown-placement-bottomLeft {

--- a/src/Select2.less
+++ b/src/Select2.less
@@ -109,7 +109,7 @@
       font-weight: bold;
       position: absolute;
       color: @text-thirdary-color;
-      top: 0;
+      top: 7px;
       right: 20px;
       &:after {
         content: '×'
@@ -171,7 +171,7 @@
     .@{__select-prefix-cls}-search__field__mirror {
       position: absolute;
       top: -999px;
-      left: 0; 
+      left: 0;
       white-space: pre;
     }
     .@{__select-prefix-cls}-selection-selected-value {
@@ -375,7 +375,7 @@
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
-        
+
         &-active {
           background-color: @brand-primary-lighter;
           cursor: pointer;
@@ -485,59 +485,59 @@
 }
 
 @keyframes slideUpIn {
-    0% {
-        opacity: 0;
-        transform-origin: 0 0;
-        transform: scaleY(.8);
-    }
+  0% {
+    opacity: 0;
+    transform-origin: 0 0;
+    transform: scaleY(.8);
+  }
 
-    100% {
-        opacity: 1;
-        transform-origin: 0 0;
-        transform: scaleY(1);
-    }
+  100% {
+    opacity: 1;
+    transform-origin: 0 0;
+    transform: scaleY(1);
+  }
 }
 
 @keyframes slideUpOut {
-    0% {
-        opacity: 1;
-        transform-origin: 0 0;
-        transform: scaleY(1);
-    }
+  0% {
+    opacity: 1;
+    transform-origin: 0 0;
+    transform: scaleY(1);
+  }
 
-    100% {
-        opacity: 0;
-        transform-origin: 0 0;
-        transform: scaleY(.8);
-    }
+  100% {
+    opacity: 0;
+    transform-origin: 0 0;
+    transform: scaleY(.8);
+  }
 }
 
 @keyframes slideDownIn {
-    0% {
-        opacity: 0;
-        transform-origin: 100% 100%;
-        transform: scaleY(.8);
-    }
+  0% {
+    opacity: 0;
+    transform-origin: 100% 100%;
+    transform: scaleY(.8);
+  }
 
-    100% {
-        opacity: 1;
-        transform-origin: 100% 100%;
-        transform: scaleY(1);
-    }
+  100% {
+    opacity: 1;
+    transform-origin: 100% 100%;
+    transform: scaleY(1);
+  }
 }
 
 @keyframes slideDownOut {
-    0% {
-        opacity: 1;
-        transform-origin: 100% 100%;
-        transform: scaleY(1);
-    }
+  0% {
+    opacity: 1;
+    transform-origin: 100% 100%;
+    transform: scaleY(1);
+  }
 
-    100% {
-        opacity: 0;
-        transform-origin: 100% 100%;
-        transform: scaleY(.8);
-    }
+  100% {
+    opacity: 0;
+    transform-origin: 100% 100%;
+    transform: scaleY(.8);
+  }
 }
 
 .@{__select-prefix-cls}-dropdown-placement-bottomLeft {


### PR DESCRIPTION
fix #15 

CSS changes, wrong style of overflow and maxHeight attributes, should be on element $prefix-dropdown-menu instead of $prefix-dropdown for trigger to calculate the right focus area.

rc-select@6.1.2 fixed it already, uxcore-select hasn't implement this fix because we override the style, refs to https://github.com/ant-design/ant-design/issues/1428
