### PR TITLE
feat: add prop rcRef to get the ref of RcSelect

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,14 @@
 
 ---
 
+## 0.5.6
+
+`NEW` add prop rcRef to get the ref of RcSelect, sometimes we need to call it's public methods
+
+## 0.5.5
+
+* `CHANGED` update placeholder color from normal-alpha-4 to normal-4
+
 ## 0.5.4
 
 * `CHANGED` support js style export

--- a/demo/Select2Demo.jsx
+++ b/demo/Select2Demo.jsx
@@ -167,6 +167,7 @@ class Demo extends React.Component {
             allowClear
             getPopupContainer={() => document.getElementById('container')}
             dropdownClassName="kuma-select2-selected-has-icon"
+            rcRef={(r) => { console.log(r); }}
           >
             <Option value="jack">
               Jack

--- a/src/Select2.jsx
+++ b/src/Select2.jsx
@@ -13,9 +13,12 @@ class Select2 extends React.Component {
     const dropdownClassName = classnames(me.props.dropdownClassName, {
       [`${me.props.prefixCls}-dropdown-${me.props.size}`]: !!me.props.size,
     });
+
     return (
       <RcSelect
-        {...this.props} className={className}
+        {...this.props}
+        ref={this.props.rcRef}
+        className={className}
         dropdownClassName={dropdownClassName}
         onSearch={(key) => { this.forceUpdate(); this.props.onSearch(key); }}
       />
@@ -26,6 +29,7 @@ Select2.displayName = 'Select2';
 Select2.RcSelect = RcSelect;
 Select2.propTypes = {
   size: PropTypes.oneOf(['large', 'middle', 'small']),
+  rcRef: PropTypes.func,
   onSearch: PropTypes.func,
 };
 Select2.defaultProps = {
@@ -33,6 +37,7 @@ Select2.defaultProps = {
   prefixCls: 'kuma-select2',
   optionLabelProp: 'children',
   transitionName: 'selectSlideUp',
+  rcRef: () => {},
   onSearch: () => {},
 };
 


### PR DESCRIPTION
add prop rcRef to get the ref of RcSelect, sometimes we need to call it's public methods, usage like normal react ref but with prop name rcRef.